### PR TITLE
Update README URLs for repo rename to ar0822-rpi-driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kernel driver for AR0822
 
-[![code formatting](https://github.com/Kurokesu/ar0822-v4l2-driver/actions/workflows/clang-format.yml/badge.svg)](https://github.com/Kurokesu/ar0822-v4l2-driver/actions/workflows/clang-format.yml)
+[![code formatting](https://github.com/Kurokesu/ar0822-rpi-driver/actions/workflows/clang-format.yml/badge.svg)](https://github.com/Kurokesu/ar0822-rpi-driver/actions/workflows/clang-format.yml)
 [![Raspberry Pi OS Bookworm](https://img.shields.io/badge/Raspberry_Pi_OS-Bookworm-blue?logo=raspberrypi)](https://www.debian.org/releases/bookworm/)
 [![Raspberry Pi OS Trixie](https://img.shields.io/badge/Raspberry_Pi_OS-Trixie-blue?logo=raspberrypi)](https://www.debian.org/releases/trixie/)
 
@@ -32,8 +32,8 @@ Clone this repository:
 
 ```bash
 cd ~
-git clone https://github.com/Kurokesu/ar0822-v4l2-driver.git
-cd ar0822-v4l2-driver/
+git clone https://github.com/Kurokesu/ar0822-rpi-driver.git
+cd ar0822-rpi-driver/
 ```
 
 Run setup script:


### PR DESCRIPTION
Renaming repo to `ar0822-rpi-driver` to keep naming consistent with the rest of Kurokesu organization's Raspberry Pi driver repos.

This PR updates `README.md` references that embed the old repo name: `code formatting` CI badge URL and `git clone` / `cd` lines in the setup instructions. Merge after the GitHub rename so the new URLs resolve.

## For existing local clones

Existing clones keep working via GitHub's redirect, but to align with the new name:

```bash
cd ~
mv ar0822-v4l2-driver ar0822-rpi-driver
cd ar0822-rpi-driver
git remote set-url origin https://github.com/Kurokesu/ar0822-rpi-driver.git
git fetch -v # verify
```