### PR TITLE
setup: Clean bare-name DKMS installs

### DIFF
--- a/.github/workflows/build-rpi.yml
+++ b/.github/workflows/build-rpi.yml
@@ -10,6 +10,9 @@ on:
       - '*.c'
       - '*.dts'
       - 'Makefile'
+      - 'dkms.conf'
+      - 'dkms.postinst'
+      - 'setup.sh'
       - '.github/workflows/build-rpi.yml'
   pull_request:
     branches: [main]
@@ -17,6 +20,9 @@ on:
       - '*.c'
       - '*.dts'
       - 'Makefile'
+      - 'dkms.conf'
+      - 'dkms.postinst'
+      - 'setup.sh'
       - '.github/workflows/build-rpi.yml'
   workflow_dispatch:
 

--- a/setup.sh
+++ b/setup.sh
@@ -33,10 +33,10 @@ if ! command -v dkms >/dev/null 2>&1; then
 	exit 1
 fi
 
-LEGACY_NAME=$(echo "$PACKAGE_NAME" | sed 's/-rpi-/-/')
+SENSOR=${PACKAGE_NAME%-rpi-dkms}
 NAMES="$PACKAGE_NAME"
-if [ "$LEGACY_NAME" != "$PACKAGE_NAME" ]; then
-	NAMES="$NAMES $LEGACY_NAME"
+if [ "$SENSOR" != "$PACKAGE_NAME" ]; then
+	NAMES="$NAMES ${SENSOR}-dkms ${SENSOR}"
 fi
 
 for name in $NAMES; do


### PR DESCRIPTION
## Summary

- Fix a gap in the setup.sh migration cleanup that missed bare-sensor-name DKMS entries. Older ar0822 installs registered modules under the bare `ar0822` name rather than the `<sensor>-dkms` variant declared in dkms.conf, and the migration cleanup imported from the imx585 scaffolding did not sweep those fossils, so `dkms install` failed on a file-owner mismatch.
- Derive the sensor stem from `PACKAGE_NAME` via POSIX parameter expansion and sweep `<sensor>-dkms` and `<sensor>` alongside the current `PACKAGE_NAME`. setup.sh remains sensor-agnostic. Non-conforming names fall through to the previous single-name behavior.
- Widen the CI paths filter to also trigger the build workflow on `dkms.conf`, `dkms.postinst` and `setup.sh` changes. Closes the coverage gap where PRs touching only install-pipeline files could not clear branch protection without a manual `workflow_dispatch` fallback.

## Test plan

- [x] Migration from bare-name fossil (`ar0822/0.0.1` from older installs). CLEAN lines for both the fossil and any current entry, install completes, module and overlay refresh cleanly.
- [x] Reinstall on top of `ar0822-rpi-dkms/0.0.1`. One CLEAN line, install completes, no WARN.
- [x] Fresh install with no legacy state. Zero CLEAN lines, install completes.
- [x] Derivation trace for `imx585-rpi-dkms`, `ar0822-rpi-dkms`, `ar0234-rpi-dkms` and a non-conforming name produces the expected NAMES lists.