### PR TITLE
dkms: Bump PACKAGE_VERSION to 0.1.0

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -2,7 +2,7 @@
 # Copyright (c) 2026, UAB Kurokesu. All rights reserved.
 
 PACKAGE_NAME="ar0822-rpi-dkms"
-PACKAGE_VERSION="0.0.1"
+PACKAGE_VERSION="0.1.0"
 
 BUILT_MODULE_NAME="ar0822"
 BUILT_MODULE_LOCATION="build"


### PR DESCRIPTION
## Summary

- Bump dkms.conf PACKAGE_VERSION from 0.0.1 to 0.1.0 for the first packaged release.
- dkms.conf on main is the version of record. debian/changelog on debian/latest already says 0.1.0-1, and the debian/rules build guard fails on any mismatch, which is the current red CI on debian/latest.

## Test plan

- [x] Merge, then re-run the failed CI on debian/latest. It checks out main fresh and should go green.